### PR TITLE
disable widget cache

### DIFF
--- a/Resources/config/config.yml
+++ b/Resources/config/config.yml
@@ -3,3 +3,4 @@ victoire_core:
         ShareThis:
             class: "Victoire\\Widget\\ShareThisBundle\\Entity\\WidgetShareThis"
             name: ShareThis
+            cache: false


### PR DESCRIPTION
This widget is only static, so the cache is not invalidated when an article slug change. 
The rendering of this widget is asynchronous so the cache is not necessary